### PR TITLE
[FIX] core: handle cors preflight with custom auth

### DIFF
--- a/addons/http_routing/models/ir_http.py
+++ b/addons/http_routing/models/ir_http.py
@@ -457,7 +457,7 @@ class IrHttp(models.AbstractModel):
         # check authentication level
         try:
             if func:
-                cls._authenticate(func.routing['auth'])
+                cls._authenticate(func)
             elif request.uid is None and request.is_frontend:
                 cls._auth_method_public()
         except Exception as e:

--- a/odoo/addons/base/models/ir_http.py
+++ b/odoo/addons/base/models/ir_http.py
@@ -108,7 +108,10 @@ class IrHttp(models.AbstractModel):
             request.uid = request.session.uid
 
     @classmethod
-    def _authenticate(cls, auth_method='user'):
+    def _authenticate(cls, endpoint):
+        auth_method = endpoint.routing["auth"]
+        if request._is_cors_preflight(endpoint):
+            auth_method = 'none'
         try:
             if request.session.uid:
                 try:
@@ -220,7 +223,7 @@ class IrHttp(models.AbstractModel):
 
         # check authentication level
         try:
-            auth_method = cls._authenticate(func.routing["auth"])
+            auth_method = cls._authenticate(func)
         except Exception as e:
             return cls._handle_exception(e)
 

--- a/odoo/addons/test_auth_custom/__init__.py
+++ b/odoo/addons/test_auth_custom/__init__.py
@@ -1,0 +1,22 @@
+from odoo import models
+from odoo.exceptions import AccessDenied
+from odoo.http import Controller, route
+
+
+class IrHttp(models.AbstractModel):
+    _inherit = 'ir.http'
+
+    @classmethod
+    def _auth_method_thing(cls):
+        raise AccessDenied()
+
+class TestController(Controller):
+    # for HTTP endpoints, must allow OPTIONS or werkzeug won't match the route
+    # when dispatching the CORS preflight
+    @route('/test_auth_custom/http', type="http", auth="thing", cors="*", methods=['GET', 'OPTIONS'])
+    def _http(self):
+        raise NotImplementedError
+
+    @route('/test_auth_custom/json', type="json", auth="thing", cors="*")
+    def _json(self):
+        raise NotImplementedError

--- a/odoo/addons/test_auth_custom/__manifest__.py
+++ b/odoo/addons/test_auth_custom/__manifest__.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+{
+    'name': 'Tests that custom auth works & is not impaired by CORS',
+    'category': 'Hidden',
+    'data': [],
+}

--- a/odoo/addons/test_auth_custom/tests/__init__.py
+++ b/odoo/addons/test_auth_custom/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_endpoints

--- a/odoo/addons/test_auth_custom/tests/test_endpoints.py
+++ b/odoo/addons/test_auth_custom/tests/test_endpoints.py
@@ -1,0 +1,46 @@
+from http import HTTPStatus
+
+import odoo.tools
+from odoo.tests import HttpCase, HOST
+
+
+class TestCustomAuth(HttpCase):
+    # suppress "WARNING: Access Error" when auth fails on json endpoints
+    @odoo.tools.mute_logger('odoo.http')
+    def test_json(self):
+        # straight request should fail
+        r = self.url_open('/test_auth_custom/json', headers={'Content-Type': 'application/json'}, data="{}")
+        e = r.json()['error']
+        self.assertEqual(e['data']['name'], 'odoo.exceptions.AccessDenied')
+
+        # but preflight should work
+        self.env['base'].flush()
+        url = "http://%s:%s/test_auth_custom/json" % (HOST, odoo.tools.config['http_port'])
+        r = self.opener.options(url, headers={
+            'Origin': 'localhost',
+            'Access-Control-Request-Method': 'QUX',
+            'Access-Control-Request-Headers': 'XYZ',
+        })
+        self.assertTrue(r.ok)
+        self.assertEqual(r.headers['Access-Control-Allow-Origin'], '*')
+        self.assertEqual(r.headers['Access-Control-Allow-Methods'], 'POST', "json is always POST")
+        self.assertNotIn('XYZ', r.headers['Access-Control-Allow-Headers'], "headers are ignored")
+
+    def test_http(self):
+        # straight request should fail
+        r = self.url_open('/test_auth_custom/http')
+        self.assertEqual(r.status_code, HTTPStatus.FORBIDDEN)
+
+        # but preflight should work
+        self.env['base'].flush()
+        url = "http://%s:%s/test_auth_custom/http" % (HOST, odoo.tools.config['http_port'])
+        r = self.opener.options(url, headers={
+            'Origin': 'localhost',
+            'Access-Control-Request-Method': 'QUX',
+            'Access-Control-Request-Headers': 'XYZ',
+        })
+        self.assertTrue(r.ok, r.text)
+        self.assertEqual(r.headers['Access-Control-Allow-Origin'], '*')
+        self.assertEqual(r.headers['Access-Control-Allow-Methods'], 'GET, OPTIONS',
+                         "http is whatever's on the endpoint")
+        self.assertNotIn('XYZ', r.headers['Access-Control-Allow-Headers'], "headers are ignored")


### PR DESCRIPTION
Odoo provides basic handling of CORS preflight requests: if an endpoint is marked as `cors=<truthy value>` then it'll automatically reply allowing the request.

*However* this is performed in `HttpRequest.dispatch` (likely in order to correctly handle the nodb case), which means it's executed after the auth handler has run... which means custom auth handlers will be called on preflight requests.

This is a problem because they are missing relevant information (e.g. which endpoint they're invoked for), plus having to deal with preflight requests in every custom auth handler is annoying, and simply allowing preflights could cause issues if the decision diverges between the auth handler and the automatic handling.

To fix this issue, extract the preflight *decision* into a separate method so we get the same decision-making process everywhere, and in case of CORS preflight set the auth to none to limit the eventual capacity for nuisance in the span between the bypassed auth and the automated preflight handling.

Also change the signature of IrHttp._authenticate so it's clearer if a callsite was forgotten somehow (and this makes for less changes and duplication at the callsites).

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
